### PR TITLE
don't show wave bug fix

### DIFF
--- a/library/src/main/java/com/cjj/MaterialRefreshLayout.java
+++ b/library/src/main/java/com/cjj/MaterialRefreshLayout.java
@@ -184,7 +184,7 @@ public class MaterialRefreshLayout extends FrameLayout {
         setHeaderHeight(Util.dip2px(context, headHeight));
 
         materialHeadView = new MaterialHeadView(context);
-        materialHeadView.setWaveColor(isShowWave ? waveColor : Color.WHITE);
+        materialHeadView.setWaveColor(isShowWave ? waveColor : Color.parseColor("#00000000"));
         materialHeadView.showProgressArrow(showArrow);
         materialHeadView.setProgressSize(progressSize);
         materialHeadView.setProgressColors(colorSchemeColors);


### PR DESCRIPTION
wave_show=false时，即下拉刷新不显示wave，把白色改成透明色